### PR TITLE
Agregué archivo de roles del equipo desde mi rama

### DIFF
--- a/docs/roles.txt
+++ b/docs/roles.txt
@@ -1,0 +1,6 @@
+Líder del proyecto: Kellys
+Colaboradores: Milton, Manuela
+
+Kellys: creó el repositorio y estructura base
+Milton: desarrollará la sección de presentación
+Manuela: escribirá el documento de análisis


### PR DESCRIPTION
Esta es mi contribución, agregando el archivo roles.txt dentro de docs/ con la asignación de funciones del equipo.